### PR TITLE
Separate test and lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ pretty:
 	isort .
 	black --line-length 120 .
 
-test:
+lint:
 	flake8
+
+test:
 	cd tests && python -m unittest discover
 	make clean
 


### PR DESCRIPTION
Motivation: testing and linting are 2 different things. Therefore the Makefile target `test` is confusing/unintuitive

Solution: Create 2 separate makefile targets