### PR TITLE
Get rid of default base transforms

### DIFF
--- a/config_template.yaml
+++ b/config_template.yaml
@@ -17,9 +17,9 @@ data:
   # col names of the image and label files. Pass multiple names as list
   image_cols: [image_1, image_2]
   label_cols: [label]
-  train: True # Use trainig dataset
-  valid: True
-  test: False
+  train: true # Use trainig dataset
+  valid: true
+  test: false
   dataset_type: persistent # iterative or persistend (chaches transforms on disk for large speedup)
   cache_dir: .monai-cache # cache dir for persistent dataset, otherwise ignored
   batch_size: 1
@@ -57,6 +57,10 @@ training:
 transforms:
   prob: 0.1
   base:
+    LoadImaged:
+      allow_missing_keys: true
+    EnsureChannelFirstd:
+      allow_missing_keys: true
     Spacingd:
       pixdim: [1, 1, 1]
       mode: [bilinear, nearest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,8 @@ ignore_missing_imports = True
 [SETUP]
 lib_name = trainlib
 branch = main
-min_python = 3.7
 version = 0.1.0
+min_python = 3.8
 requirements =
   monai[itk,pynrrd,pydicom,ignite,tqdm,pyyaml,tensorboard,nibabel]==1.0.0
   codecarbon

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,8 @@ ignore_missing_imports = True
 [SETUP]
 lib_name = trainlib
 branch = main
-version = 0.1.0
 min_python = 3.8
+version = 0.2.0
 requirements =
   monai[itk,pynrrd,pydicom,ignite,tqdm,pyyaml,tensorboard,nibabel]==1.0.0
   codecarbon

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -44,8 +44,13 @@ training:
   early_stopping_patience: 2
   max_epochs: 2
 transforms:
-  Spacingd:
-    pixdim: [2, 2, 2]
-    mode: [bilinear, nearest]
+  base:
+    LoadImaged:
+      allow_missing_keys: true
+    EnsureChannelFirstd:
+      allow_missing_keys: true
+    Spacingd:
+      pixdim: [2, 2, 2]
+      mode: [bilinear, nearest]
   orientation: RAS
   prob: 0.1

--- a/trainlib/transforms.py
+++ b/trainlib/transforms.py
@@ -42,10 +42,7 @@ def get_transform(tfm_name: str, config: munch.Munch, **kwargs):
 
 def get_base_transforms(config: munch.Munch) -> List[Callable]:
     """Transforms applied everytime at the start of the transform pipeline"""
-    tfms = [
-        get_transform("LoadImaged", config=config, allow_missing_keys=True),
-        get_transform("EnsureChannelFirstd", config=config, allow_missing_keys=True),
-    ]
+    tfms = []
     if "base" in config.transforms.keys():
         tfm_names = list(config.transforms.base)
         tfms += [get_transform(tn, config) for tn in tfm_names]


### PR DESCRIPTION
Resolves https://github.com/kbressem/trainlib/issues/44

**Changes:**
- remove default base transforms in `transforms.py`
- Adjust both configs in this file

Note: configs in other code bases (other than this repo) have to be adapted by respective authors after merging this