### PR TITLE
Make possible that data_dir includes tilde ~

### DIFF
--- a/tests/test_trainlib_utils.py
+++ b/tests/test_trainlib_utils.py
@@ -1,4 +1,5 @@
 import multiprocessing
+from pathlib import Path
 import tempfile
 import unittest
 
@@ -21,6 +22,7 @@ class TestLoadConfig(unittest.TestCase):
         config = load_config("test_config.yaml")
         self.assertIsInstance(config, dict)
         self.assertIsInstance(config, munch.Munch)
+        self.assertIsInstance(config.data.data_dir, Path)
 
     def test_listification(self):
         """Test that image_cols and label_cols are converted to lists"""

--- a/trainlib/data.py
+++ b/trainlib/data.py
@@ -142,9 +142,9 @@ def segmentation_dataloaders(
 
     for col in image_cols + label_cols:
         # create absolute file name from relative fn in df and data_dir
-        train_df[col] = data_dir + train_df[col]
-        valid_df[col] = data_dir + valid_df[col]
-        test_df[col] = data_dir + test_df[col]
+        train_df[col] = data_dir / train_df[col]
+        valid_df[col] = data_dir / valid_df[col]
+        test_df[col] = data_dir / test_df[col]
 
     # Dataframes should now be converted to a dict
     # The data_dict looks like this:

--- a/trainlib/utils.py
+++ b/trainlib/utils.py
@@ -32,6 +32,7 @@ def load_config(fn: str = "config.yaml") -> munch.Munch:
     run_id = Path(config.run_id)
     config.out_dir = run_id / config.out_dir
     config.log_dir = run_id / config.log_dir
+    config.data.data_dir = Path(config.data.data_dir).expanduser()
 
     if not isinstance(config.data.image_cols, (tuple, list)):
         config.data.image_cols = [config.data.image_cols]


### PR DESCRIPTION
Motivation: Allow data_dir can be set to include tilde. 

**Example:**
`~/my_data` (Note the tilde ~ character, which stands for user dir, which is different according to your OS)