### PR TITLE
Remove black from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: black
-      run: |
-        black -l 120 --check trainlib tests
+#    - name: black
+#      run: |
+#        black -l 120 --check trainlib tests
     - name: type checking with mypy
       run: |
         python -m pip install types-PyYAML types-attrs types-pyOpenSSL types-requests types-setuptools


### PR DESCRIPTION
We use isort and black to sort our imports. However, isort and black treat imports a bit differently. I prefer to run black first and isort second. This way, black will request changes in the CI. 

We already to linting with flake8, so running black again might be to much.  